### PR TITLE
Fix GitHub Actions workflow for new project structure

### DIFF
--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -17,17 +17,13 @@ jobs:
         with:
           node-version: '18'
           cache: 'npm'
-          cache-dependency-path: cli/package-lock.json
+          cache-dependency-path: package-lock.json
       
       - name: Install dependencies
-        run: |
-          cd cli
-          npm ci
+        run: npm ci
       
       - name: Run tests
-        run: |
-          cd cli
-          npm test
+        run: npm test
 
   publish:
     needs: test
@@ -42,30 +38,23 @@ jobs:
           node-version: '18'
           registry-url: 'https://registry.npmjs.org'
           cache: 'npm'
-          cache-dependency-path: cli/package-lock.json
+          cache-dependency-path: package-lock.json
       
       - name: Install dependencies
-        run: |
-          cd cli
-          npm ci
+        run: npm ci
       
       - name: Extract version from tag
         id: version
         run: echo "VERSION=${GITHUB_REF#refs/tags/v}" >> $GITHUB_OUTPUT
       
       - name: Update package version
-        run: |
-          cd cli
-          npm version ${{ steps.version.outputs.VERSION }} --no-git-tag-version
+        run: npm version ${{ steps.version.outputs.VERSION }} --no-git-tag-version
       
       - name: Security audit
-        run: |
-          cd cli
-          npm audit --audit-level high
+        run: npm audit --audit-level high
       
       - name: Check for sensitive files
         run: |
-          cd cli
           # Check if any .env files exist in the package
           if npm pack --dry-run | grep -E '\.(env|key|pem|p12)$'; then
             echo "❌ Sensitive files detected in package!"
@@ -75,14 +64,12 @@ jobs:
       
       - name: Build (if needed)
         run: |
-          cd cli
           # Add build step here if you have one
           # npm run build
+          echo "No build step required"
       
       - name: Publish to NPM
-        run: |
-          cd cli
-          npm publish --access public
+        run: npm publish --access public
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
       


### PR DESCRIPTION
## Summary
- Update GitHub Actions npm-publish workflow for restructured project
- Remove references to old `cli/` subdirectory
- Fix paths for npm commands and cache dependencies

## Changes
- Updated `cache-dependency-path` from `cli/package-lock.json` to `package-lock.json`
- Removed `cd cli` commands from all steps
- Updated npm commands to run from project root
- Maintained npm publish and GitHub release functionality

## Why
After restructuring the project to support npm global installation, the GitHub Actions workflow was still referencing the old `cli/` subdirectory structure, which would cause failures when creating releases.

## Test plan
- [x] Verify workflow file syntax is correct
- [x] Confirm all path references are updated
- [ ] Test with actual tag push (after merge)

This enables proper automated npm publishing and GitHub releases when version tags are pushed.